### PR TITLE
Change to regular double quotes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ pyffx
 pyffx is a pure Python implementation of *Format-preserving, Feistel-based encryption* (FFX).
 
 * `The FFX Mode of Operation for Format-Preserving Encryption`_
-* `Addendum to “The FFX Mode of Operation for Format-Preserving Encryption”`_
+* `Addendum to "The FFX Mode of Operation for Format-Preserving Encryption"`_
 
 Only method 2 is implemented.
 
@@ -32,5 +32,5 @@ Usage
     'aaabbb'
 
 .. _The FFX Mode of Operation for Format-Preserving Encryption: http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/ffx/ffx-spec.pdf
-.. _Addendum to “The FFX Mode of Operation for Format-Preserving Encryption”: http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/ffx/ffx-spec2.pdf
+.. _Addendum to "The FFX Mode of Operation for Format-Preserving Encryption": http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/ffx/ffx-spec2.pdf
 .. _libffx: https://github.com/kpdyer/libffx


### PR DESCRIPTION
Encountered problems during pip install:

File "/tmp/pip-build-jgq8xkxi/pyffx/setup.py", line 6, in <module>
build	02-Jul-2018 16:11:14	        description = f.read()
build	02-Jul-2018 16:11:14	      File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
build	02-Jul-2018 16:11:14	        return codecs.ascii_decode(input, self.errors)[0]
build	02-Jul-2018 16:11:14	    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 305: ordinal not in range(128)